### PR TITLE
Made slug_field optional and default to 'slug'.

### DIFF
--- a/mptt_urls/__init__.py
+++ b/mptt_urls/__init__.py
@@ -7,7 +7,7 @@ def _load(module):
 
 
 class view():
-    def __init__(self, model, view, slug_field):
+    def __init__(self, model, view, slug_field='slug'):
         self.model = _load(model)
         self.view = _load(view)
         self.slug_field = slug_field


### PR DESCRIPTION
This way you could call the `view` this way:
```python
mptt_urls.view(model=Category, view=views.category_detail)
```